### PR TITLE
Fix bug in Part4Grader

### DIFF
--- a/src/main/java/com/github/lernejo/korekto/grader/amqp/parts/Part4Grader.java
+++ b/src/main/java/com/github/lernejo/korekto/grader/amqp/parts/Part4Grader.java
@@ -105,7 +105,7 @@ public class Part4Grader implements PartGrader {
             // Wait fot the client app to boot
 
             for (int i = 0; i < callNbr; i++) {
-                writeInput(process.process(), "message " + i + "\n");
+                writeInput(process.process(), "message:" + i + "\n");
             }
 
             readAllOutputLogs(process);
@@ -130,7 +130,7 @@ public class Part4Grader implements PartGrader {
             int messagesToSend = 15 - callNbr;
 
             for (int i = callNbr; i < messagesToSend; i++) {
-                writeInput(process.process(), "message " + i + "\n");
+                writeInput(process.process(), "message:" + i + "\n");
             }
 
             writeInput(process.process(), "q\n");


### PR DESCRIPTION
L'espace dans le message envoyé à la fonction `writeInput()` cause le BufferedReader à produire deux lignes au lieu d'une seule, ce qui fausse les résultats du test.

![Capture_2021-12-09_a_10 12 04](https://user-images.githubusercontent.com/71343264/145490158-e9d97e23-5c47-4841-8255-e97ed89d8fa4.jpg)

